### PR TITLE
add providers option

### DIFF
--- a/src/index.node.js
+++ b/src/index.node.js
@@ -1,4 +1,4 @@
-import { utils } from 'ethers';
+import { utils, providers } from 'ethers';
 
 import SynthetixJsBase from './SynthetixJsBase';
 import PrivateKey from '../lib/signers/privateKeySigner';
@@ -24,3 +24,4 @@ export class SynthetixJs extends SynthetixJsBase {
 
 SynthetixJs.signers = signers;
 SynthetixJs.utils = utils; // shortcut to ethers utils without having to create instance
+SynthetixJs.providers = providers;


### PR DESCRIPTION
Export the `providers` field from `ethers` so that a consumer of SynthetixJs can construct and inject a custom provider.
see issue #38 .