### PR TITLE
ci: add dockerhub auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: 'circleci/node:10.16'
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     working_directory: null
     steps:
       - checkout


### PR DESCRIPTION
Added docker authentication while pulling images.

https://support.circleci.com/hc/en-us/articles/360050623311-Docker-Hub-rate-limiting-FAQ

Signed-off-by: Jakub Mucha jakub.mucha@icloud.com